### PR TITLE
Add automated tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,7 +2,7 @@ name: Run Tests
 
 on:
   push:
-    branches: [ "*" ]
+    branches: [ main ]
   pull_request:
     branches: [ main ]
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,4 +1,4 @@
-name: Run Tests
+name: Unit tests
 
 on:
   push:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,7 +23,17 @@ jobs:
         python -m pip install --upgrade pip
         pip install -r requirements.txt
         pip install -r requirements-test.txt
+        pip install pytest-cov
 
-    - name: Run tests with pytest
+    - name: Run tests with coverage
       run: |
-        pytest tests/ -v
+        pytest tests/ -v --cov=. --cov-report=xml --cov-report=term
+
+    - name: Upload coverage to Codecov
+      uses: codecov/codecov-action@v5
+      with:
+        token: ${{ secrets.CODECOV_TOKEN }}
+        file: ./coverage.xml
+        flags: unittests
+        name: codecov-umbrella
+        fail_ci_if_error: false

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,29 @@
+name: Run Tests
+
+on:
+  push:
+    branches: [ "*" ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Set up Python 3.12
+      uses: actions/setup-python@v5
+      with:
+        python-version: '3.12'
+
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install -r requirements.txt
+        pip install -r requirements-test.txt
+
+    - name: Run tests with pytest
+      run: |
+        pytest tests/ -v

--- a/main.py
+++ b/main.py
@@ -17,12 +17,11 @@ logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 
 
-def is_coffee_execution_week():
+def is_coffee_execution_week(date: datetime.date):
     """
-    Determines if current week is odd (coffee duty week).
+    Determines if given date's week is odd (coffee duty week).
     """
-    today = datetime.date.today()
-    iso_week_number = today.isocalendar()[1]
+    iso_week_number = date.isocalendar()[1]
     is_current_week_odd = (iso_week_number % 2 == 1)
     logger.info(
         f"Week number {iso_week_number} is {'odd' if is_current_week_odd else 'even'} "
@@ -31,15 +30,14 @@ def is_coffee_execution_week():
     return is_current_week_odd
 
 
-def is_fridge_execution_week():
+def is_fridge_execution_week(date: datetime.date):
     """
-    Determines if this is the last Wednesday of the month.
+    Determines if the given date is the last Wednesday of the month.
     """
-    today = datetime.date.today()
-    next_week = today + datetime.timedelta(days=7)
-    is_last_wednesday = (today.month != next_week.month)
+    next_week = date + datetime.timedelta(days=7)
+    is_last_wednesday = (date.month != next_week.month)
     logger.info(
-        f"{today} is {'the' if is_last_wednesday else 'not the'} last Wednesday "
+        f"{date} is {'the' if is_last_wednesday else 'not the'} last Wednesday "
         f"of the month so {'we are' if is_last_wednesday else 'not'} executing fridge job"
     )
     return is_last_wednesday
@@ -124,7 +122,8 @@ def assign_coffee_duty(request):
     test_mode = request_json.get("test_mode", True)
 
     # Check if it's execution week
-    if not is_coffee_execution_week():
+    today = datetime.date.today()
+    if not is_coffee_execution_week(today):
         if test_mode:
             logger.info("Would not have assigned coffee duty this week.")
         else:
@@ -147,7 +146,8 @@ def assign_fridge_duty(request):
     test_mode = request_json.get("test_mode", True)
 
     # Check if it's execution week
-    if not is_fridge_execution_week():
+    today = datetime.date.today()
+    if not is_fridge_execution_week(today):
         if test_mode:
             logger.info("Would not have assigned fridge duty this week.")
         else:

--- a/main.py
+++ b/main.py
@@ -4,14 +4,11 @@ import random
 
 import functions_framework
 
-from database import (
-    get_office_members,
-    get_current_cycle_info,
-    start_new_cycle,
-    record_duty_assignment
+from database import get_office_members, get_current_cycle_info, start_new_cycle, record_duty_assignment
+from models import OfficeMember, DutyType, DutyConfig
+from mattermost import (
+    configure_and_send_mattermost_webhook,
 )
-from models import OfficeMember, DutyType
-from mattermost import send_mattermost_coffee_webhook, send_mattermost_fridge_webhook
 
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
@@ -22,7 +19,7 @@ def is_coffee_execution_week(date: datetime.date):
     Determines if given date's week is odd (coffee duty week).
     """
     iso_week_number = date.isocalendar()[1]
-    is_current_week_odd = (iso_week_number % 2 == 1)
+    is_current_week_odd = iso_week_number % 2 == 1
     logger.info(
         f"Week number {iso_week_number} is {'odd' if is_current_week_odd else 'even'} "
         f"so {'we are' if is_current_week_odd else 'not'} executing coffee job..."
@@ -35,7 +32,7 @@ def is_fridge_execution_week(date: datetime.date):
     Determines if the given date is the last Wednesday of the month.
     """
     next_week = date + datetime.timedelta(days=7)
-    is_last_wednesday = (date.month != next_week.month)
+    is_last_wednesday = date.month != next_week.month
     logger.info(
         f"{date} is {'the' if is_last_wednesday else 'not the'} last Wednesday "
         f"of the month so {'we are' if is_last_wednesday else 'not'} executing fridge job"
@@ -43,70 +40,82 @@ def is_fridge_execution_week(date: datetime.date):
     return is_last_wednesday
 
 
+def get_duty_config(duty_type: DutyType) -> DutyConfig:
+    """
+    Get configuration for a specific duty type.
+    """
+    if duty_type == DutyType.COFFEE:
+        return DutyConfig(coffee_drinkers_only=True, duty_name="coffee machine cleaning")
+    elif duty_type == DutyType.FRIDGE:
+        return DutyConfig(coffee_drinkers_only=False, duty_name="fridge cleaning")
+    else:
+        raise ValueError(f"Unknown duty type {duty_type}")
+
+
+def select_next_member(members: list[OfficeMember], assigned_member_ids: set[int]) -> OfficeMember | None:
+    """
+    Select the next member for duty from available members.
+    Returns None if all members have been assigned.
+    """
+    member_lookup = {member.id: member for member in members}
+    all_member_ids = set(member_lookup.keys())
+    available_user_ids = list(all_member_ids - assigned_member_ids)
+
+    if not available_user_ids:
+        return None
+
+    selected_user_id = random.choice(available_user_ids)
+    return member_lookup[selected_user_id]
+
+
 def _assign_duty(duty_type: DutyType, test_mode: bool = False):
     """
     Assign a duty, track it in the database, and send a notification on Mattermost.
     """
+    # Get duty configuration
+    config = get_duty_config(duty_type)
+
     # Get eligible members from database
-    if duty_type == DutyType.COFFEE:
-        members = get_office_members(coffee_drinkers_only=True, test_mode=test_mode)
-        notification_func = send_mattermost_coffee_webhook
-        duty_name = "coffee machine cleaning"
-    else:
-        members = get_office_members(coffee_drinkers_only=False, test_mode=test_mode)
-        notification_func = send_mattermost_fridge_webhook
-        duty_name = "fridge cleaning"
-
+    members = get_office_members(coffee_drinkers_only=config.coffee_drinkers_only, test_mode=test_mode)
     if not members:
-        logger.warning(f"No members eligible for {duty_name}. Aborting.")
-        return {"status": "error", "message": f"No members eligible for {duty_name}"}, 500
+        logger.warning(f"No members eligible for {config.duty_name}. Aborting.")
+        return {"status": "error", "message": f"No members eligible for {config.duty_name}"}, 500
 
-    # Create member lookup
-    member_lookup = {member.id: member for member in members}
-    all_member_ids = set(member_lookup.keys())
-
-    # Get cycle info
+    # Get current cycle and select member
     cycle_info = get_current_cycle_info(duty_type, test_mode)
-    available_user_ids = list(all_member_ids - cycle_info.assigned_member_ids)
+    selected_member = select_next_member(members, cycle_info.assigned_member_ids)
 
     # Start new cycle if needed
-    if not available_user_ids:
-        logger.info(f"All users have had a turn for {duty_name}. Starting new cycle.")
+    if selected_member is None:
+        logger.info(f"All users have had a turn for {config.duty_name}. Starting new cycle.")
         cycle_info = start_new_cycle(duty_type, test_mode)
-        available_user_ids = list(all_member_ids)
+        selected_member = select_next_member(members, cycle_info.assigned_member_ids)
 
-        if not available_user_ids:
-            logger.error(f"No users available for {duty_name} even after cycle reset.")
-            return {"status": "error",
-                    "message": f"No users available for {duty_name} after cycle reset."}, 500
+        if selected_member is None:
+            logger.error(f"No users available for {config.duty_name} even after cycle reset.")
+            return {"status": "error", "message": f"No users available for {config.duty_name} after cycle reset."}, 500
 
-    # Select random user
-    selected_user_id = random.choice(available_user_ids)
-    selected_member = member_lookup[selected_user_id]
-
-    logger.info(
-        f"Selected user for {duty_name}: {selected_member.username} (ID: {selected_user_id})")
+    logger.info(f"Selected user for {config.duty_name}: {selected_member.username} (ID: {selected_member.id})")
 
     # Send notification
-    if not notification_func(selected_member.username, test_mode=test_mode):
+    if not configure_and_send_mattermost_webhook(selected_member.username, duty_type=duty_type, test_mode=test_mode):
         logger.error(f"Failed to send Mattermost webhook for {selected_member.username}")
 
     # Record assignment
     result = record_duty_assignment(
-        member_id=selected_user_id,
+        member_id=selected_member.id,
         username=selected_member.username,
         duty_type=duty_type,
         cycle_id=cycle_info.cycle_id,
-        test_mode=test_mode
+        test_mode=test_mode,
     )
 
     if not result.success:
         logger.error(f"Failed to record {selected_member.username} in database: {result.message}")
         return {"status": "error", "message": result.message}, 500
 
-    logger.info(f"{duty_name} assignment process completed successfully.")
-    return {"status": "success",
-            "message": f"Assigned {duty_name} to {selected_member.username}."}, 200
+    logger.info(f"{config.duty_name} assignment process completed successfully.")
+    return {"status": "success", "message": f"Assigned {config.duty_name} to {selected_member.username}."}, 200
 
 
 @functions_framework.http

--- a/mattermost.py
+++ b/mattermost.py
@@ -4,39 +4,71 @@ import random
 
 import requests
 
+from models import DutyType
+
 MATTERMOST_WEBHOOK_URL = os.environ.get("MATTERMOST_WEBHOOK_URL")
 
 logger = logging.getLogger(__name__)
 
+COFFEE_GREETINGS = [
+    "Hey team!",
+    "Good afternoon, coffee lovers!",
+    "Your biweekly coffee reminder is here!",
+    "Hello everyone!",
+    "Time for our coffee care update!",
+    "Happy coffee week!",
+    "Ready for a fresh brew?",
+    "Greetings, coffee crew!",
+]
 
-def send_mattermost_coffee_webhook(username, test_mode=True):
-    """
-    Sends a message to the configured Mattermost incoming webhook, for the coffee bot.
-    """
+FRIDGE_GREETINGS = [
+    "Hey team!",
+    "Good afternoon, hungry folks!",
+    "Your monthly fridge reminder is here!",
+    "Hello everyone!",
+    "Time for our fridge care update!",
+    "Happy fridge cleaning day!",
+    "Ready for a fresh fridge?",
+    "Fridge cleaning time!",
+    "Hello, clean fridge champions!",
+]
 
-    greetings = ["Hey team!",
-                 "Good afternoon, coffee lovers!",
-                 "Your biweekly coffee reminder is here!",
-                 "Hello everyone!",
-                 "Time for our coffee care update!",
-                 "Happy coffee week!",
-                 "Ready for a fresh brew?",
-                 "Greetings, coffee crew!"]
+
+def configure_and_send_mattermost_webhook(username: str, duty_type: DutyType, test_mode: bool = True) -> bool:
+    """
+    Build and send a message to the configured Mattermost incoming webhook.
+    """
+    if duty_type == DutyType.COFFEE:
+        greetings = COFFEE_GREETINGS
+        machine_to_clean = "coffee machine"
+        emoji = "✨"
+    elif duty_type == DutyType.FRIDGE:
+        greetings = FRIDGE_GREETINGS
+        machine_to_clean = "fridge"
+        emoji = "🧼"
+    else:
+        raise ValueError("Unsupported duty type for Mattermost")
 
     if test_mode is True:
-        message = (f"☕️ {random.choice(greetings)} ☕️\nIt's {username}'s turn to clean the coffee "
-                   f"machine this week! ✨ Click [here](https://clean-office-command-center.vercel.app/) "
-                   f"for instructions, and to mark the job as completed.")
+        message = (
+            f"☕️ {random.choice(greetings)} ☕️\nIt's {username}'s turn to clean the "
+            f"{machine_to_clean} this week! {emoji} Click "
+            f"[here](https://clean-office-command-center.vercel.app/) for instructions, and "
+            f"to mark the job as completed."
+        )
 
     else:
-        message = (f"☕️ {random.choice(greetings)} ☕️\nIt's @{username}'s turn to clean the coffee "
-                   f"machine this week! ✨ Click [here](https://clean-office-command-center.vercel.app/) "
-                   f"for instructions, and to mark the job as completed.")
+        message = (
+            f"☕️ {random.choice(greetings)} ☕️\nIt's @{username}'s turn to clean the "
+            f"{machine_to_clean} this week! {emoji} Click "
+            f"[here](https://clean-office-command-center.vercel.app/) for instructions, and "
+            f"to mark the job as completed."
+        )
 
     payload = {
         "text": message,
         "icon_url": "https://storage.cloud.google.com/public-images-java-janitor/java-janitor.png",
-        "username": "Java Janitor"
+        "username": "Java Janitor",
     }
 
     if test_mode is True:
@@ -46,39 +78,6 @@ def send_mattermost_coffee_webhook(username, test_mode=True):
 
     return send_mattermost_webhook(username, payload)
 
-def send_mattermost_fridge_webhook(username, test_mode=True):
-    """
-    Sends a message to the configured Mattermost incoming webhook, for the fridge bot.
-    """
-
-    greetings = ["Hey team!",
-                "Good afternoon, hungry folks!",
-                "Your monthly fridge reminder is here!",
-                "Hello everyone!",
-                "Time for our fridge care update!",
-                "Happy fridge cleaning day!",
-                "Ready for a fresh fridge?",
-                "Fridge cleaning time!",
-                "Hello, clean fridge champions!"]
-
-    if test_mode is True:
-        message = (f"☕️ {random.choice(greetings)} :soap: \nIt's {username}'s turn to clean the fridge "
-                   f"this week! ✨ Click [here](https://clean-office-command-center.vercel.app/) "
-                   f"for instructions, and to mark the job as completed.")
-
-    else:
-        message = (f"☕️ {random.choice(greetings)} :soap: It's @{username}'s turn to clean the fridge "
-                   f"this week! ✨ Click [here](https://clean-office-command-center.vercel.app/) "
-                   f"for instructions, and to mark the job as completed.")
-
-    payload = {
-        "text": message,
-        "icon_url": "https://storage.cloud.google.com/public-images-java-janitor/fridge-warden.jpg",
-        "username": "Fridge Warden",
-        "channel": "@lotte_lutkenhaus" if test_mode is True else "nycoffice",
-    }
-
-    return send_mattermost_webhook(username, payload)
 
 def send_mattermost_webhook(username, payload):
     """

--- a/models.py
+++ b/models.py
@@ -1,5 +1,7 @@
 from datetime import datetime
+from dataclasses import dataclass
 from enum import StrEnum
+from typing import Callable
 from pydantic import BaseModel
 
 
@@ -33,3 +35,9 @@ class CycleInfo(BaseModel):
 class AssignmentResult(BaseModel):
     success: bool
     message: str
+
+
+@dataclass
+class DutyConfig:
+    coffee_drinkers_only: bool
+    duty_name: str

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,18 @@
+[tool.ruff]
+line-length = 120
+target-version = "py39"
+
+[tool.ruff.lint]
+select = [
+    "E",   # pycodestyle errors
+    "W",   # pycodestyle warnings
+    "F",   # pyflakes
+    "I",   # isort
+    "B",   # flake8-bugbear
+    "UP",  # pyupgrade
+]
+ignore = []
+
+[tool.ruff.format]
+quote-style = "double"
+indent-style = "space"

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,10 @@
+[pytest]
+testpaths = tests
+python_files = test_*.py
+python_classes = Test*
+python_functions = test_*
+addopts = -v --tb=short --strict-markers
+markers =
+    unit: Unit tests
+    integration: Integration tests
+    slow: Tests that take a long time to run

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,4 +1,4 @@
 pytest==8.3.3
 pytest-cov==5.0.0
 pytest-mock==3.14.0
-freezegun==1.5.1
+ruff==0.13.2

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,0 +1,4 @@
+pytest==8.3.3
+pytest-cov==5.0.0
+pytest-mock==3.14.0
+freezegun==1.5.1

--- a/tests/test_date_utils.py
+++ b/tests/test_date_utils.py
@@ -1,0 +1,28 @@
+import datetime
+import pytest
+
+from main import is_coffee_execution_week, is_fridge_execution_week
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("test_date,expected", [
+    (datetime.date(2024, 1, 3), True),    # Week 1 (odd) - Wednesday
+    (datetime.date(2024, 1, 10), False),  # Week 2 (even) - Wednesday  
+    (datetime.date(2024, 1, 17), True),   # Week 3 (odd) - Wednesday
+    (datetime.date(2023, 12, 27), False), # Week 52 (even) - Wednesday
+])
+def test_coffee_execution_week(test_date, expected):
+    assert is_coffee_execution_week(test_date) == expected
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("test_date,expected", [
+    (datetime.date(2024, 1, 31), True),   # Last Wednesday of January
+    (datetime.date(2024, 1, 24), False),  # Not the last Wednesday
+    (datetime.date(2024, 3, 27), True),   # Last Wednesday of March
+    (datetime.date(2024, 3, 20), False),  # Not last Wednesday of March
+    (datetime.date(2024, 12, 25), True),  # Last Wednesday of December
+    (datetime.date(2024, 6, 18), False),  # Not last Wednesday of December
+])
+def test_fridge_execution_week(test_date, expected):
+    assert is_fridge_execution_week(test_date) == expected

--- a/tests/test_date_utils.py
+++ b/tests/test_date_utils.py
@@ -5,24 +5,30 @@ from main import is_coffee_execution_week, is_fridge_execution_week
 
 
 @pytest.mark.unit
-@pytest.mark.parametrize("test_date,expected", [
-    (datetime.date(2024, 1, 3), True),    # Week 1 (odd) - Wednesday
-    (datetime.date(2024, 1, 10), False),  # Week 2 (even) - Wednesday  
-    (datetime.date(2024, 1, 17), True),   # Week 3 (odd) - Wednesday
-    (datetime.date(2023, 12, 27), False), # Week 52 (even) - Wednesday
-])
+@pytest.mark.parametrize(
+    "test_date,expected",
+    [
+        (datetime.date(2024, 1, 3), True),  # Week 1 (odd) - Wednesday
+        (datetime.date(2024, 1, 10), False),  # Week 2 (even) - Wednesday
+        (datetime.date(2024, 1, 17), True),  # Week 3 (odd) - Wednesday
+        (datetime.date(2023, 12, 27), False),  # Week 52 (even) - Wednesday
+    ],
+)
 def test_coffee_execution_week(test_date, expected):
     assert is_coffee_execution_week(test_date) == expected
 
 
 @pytest.mark.unit
-@pytest.mark.parametrize("test_date,expected", [
-    (datetime.date(2024, 1, 31), True),   # Last Wednesday of January
-    (datetime.date(2024, 1, 24), False),  # Not the last Wednesday
-    (datetime.date(2024, 3, 27), True),   # Last Wednesday of March
-    (datetime.date(2024, 3, 20), False),  # Not last Wednesday of March
-    (datetime.date(2024, 12, 25), True),  # Last Wednesday of December
-    (datetime.date(2024, 6, 18), False),  # Not last Wednesday of December
-])
+@pytest.mark.parametrize(
+    "test_date,expected",
+    [
+        (datetime.date(2024, 1, 31), True),  # Last Wednesday of January
+        (datetime.date(2024, 1, 24), False),  # Not the last Wednesday
+        (datetime.date(2024, 3, 27), True),  # Last Wednesday of March
+        (datetime.date(2024, 3, 20), False),  # Not last Wednesday of March
+        (datetime.date(2024, 12, 25), True),  # Last Wednesday of December
+        (datetime.date(2024, 6, 18), False),  # Not last Wednesday of December
+    ],
+)
 def test_fridge_execution_week(test_date, expected):
     assert is_fridge_execution_week(test_date) == expected

--- a/tests/test_duty_assignment.py
+++ b/tests/test_duty_assignment.py
@@ -55,7 +55,7 @@ def test_select_next_member(case: TestCase):
     Test member selection logic
     """
     result = select_next_member(case.members, case.assigned_ids)
-    if len(case.expected_id) > 1:
+    if isinstance(case.expected_id, set):
         assert result in case.expected_id
     else:
         assert result == case.expected_id

--- a/tests/test_duty_assignment.py
+++ b/tests/test_duty_assignment.py
@@ -44,21 +44,27 @@ test_cases = [
             OfficeMember(id=3, username="ellie"),
         ],
         assigned_ids=set(),
-        expected_id={1, 2, 3}  # Can be any of 1, 2, 3
+        expected_id={1, 2, 3}
     ),
 ]
 
 @pytest.mark.unit
 @pytest.mark.parametrize("case", test_cases, ids=lambda case: case.rationale)
-def test_select_next_member(case: TestCase):
+def test_select_next_member(case: TestCase) -> None:
     """
     Test member selection logic
     """
     result = select_next_member(case.members, case.assigned_ids)
+
+    if case.expected_id is None:
+        assert result is None
+        return
+
     if isinstance(case.expected_id, set):
-        assert result in case.expected_id
-    else:
-        assert result == case.expected_id
+        assert result.id in case.expected_id
+        return
+
+    assert result.id == case.expected_id
 
 
 @pytest.mark.unit

--- a/tests/test_duty_assignment.py
+++ b/tests/test_duty_assignment.py
@@ -1,0 +1,85 @@
+import pytest
+from dataclasses import dataclass
+from models import OfficeMember, DutyType, DutyConfig
+from main import select_next_member, get_duty_config
+
+
+@dataclass
+class TestCase:
+    rationale: str
+    members: list[OfficeMember]
+    assigned_ids: set[int]
+    expected_id: int | set[int] | None
+
+test_cases = [
+    TestCase(
+        rationale="Should select Abel as the only unassigned member",
+        members=[
+            OfficeMember(id=1, username="lotte"),
+            OfficeMember(id=2, username="abel"),
+        ],
+        assigned_ids={1},
+        expected_id=2
+    ),
+    TestCase(
+        rationale="Should return None as all members have had a turn",
+        members=[
+            OfficeMember(id=1, username="lotte"),
+            OfficeMember(id=2, username="abel"),
+        ],
+        assigned_ids={1, 2},
+        expected_id=None
+    ),
+    TestCase(
+        rationale="Should return None as we have no members available",
+        members=[],
+        assigned_ids={1, 2},
+        expected_id=None
+    ),
+    TestCase(
+        rationale="Should select from all as none have had a turn",
+        members=[
+            OfficeMember(id=1, username="lotte"),
+            OfficeMember(id=2, username="abel"),
+            OfficeMember(id=3, username="ellie"),
+        ],
+        assigned_ids=set(),
+        expected_id={1, 2, 3}  # Can be any of 1, 2, 3
+    ),
+]
+
+@pytest.mark.unit
+@pytest.mark.parametrize("case", test_cases, ids=lambda case: case.rationale)
+def test_select_next_member(case: TestCase):
+    """
+    Test member selection logic
+    """
+    result = select_next_member(case.members, case.assigned_ids)
+    if len(case.expected_id) > 1:
+        assert result in case.expected_id
+    else:
+        assert result == case.expected_id
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("duty_type", DutyType)
+def test_get_duty_config(duty_type: DutyType):
+    """
+    Test getting duty configuration
+    """
+    config = get_duty_config(duty_type)
+    
+    assert isinstance(config, DutyConfig)
+    if duty_type == DutyType.COFFEE:
+        assert config.coffee_drinkers_only == True
+    else:
+        assert config.coffee_drinkers_only == False
+
+
+@pytest.mark.unit
+def test_get_duty_config_invalid_type():
+    """
+    Test that invalid duty type raises ValueError
+    """
+    with pytest.raises(ValueError, match="Unknown duty type"):
+        get_duty_config("invalid_type")


### PR DESCRIPTION
Adds some automated tests for the repo. Currently, only covers date utils and assignment logic, but we should extend this with a more extensive test for assignment, and some tests that cover the database functionality. To aid in testing the assignment logic, I've split up the larger `_assign_duty()` method into smaller sections that are easier to test. 

PR also contains changes related to running ruff. 